### PR TITLE
custom-border label with shell variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,10 +227,19 @@ Run `man fzf-tmux` to learn more about the available options.
 
 ### Custom Border Label
 
-If you want to customize the fzf popup, you can set the `@t-fzf-border-label` variable in your `tmux.conf`:
-```sh
-set -g @t-fzf-border-label ' YOUR OWN BORDER LABEL '
+If you want to customize the fzf popup border label, you can add `T_FZF_BORDER_LABEL` to your shell variable
+
+```bash
+# ~/.bashrc or ~/.zshrc
+export T_FZF_BORDER_LABEL=' Your Custom Label '
 ```
+or if you use fish:
+
+```fish
+# ~/.config/fish/config.fish
+set -Ux T_FZF_BORDER_LABEL " Your Custom Label "
+```
+
 
 ## Background
 

--- a/bin/t
+++ b/bin/t
@@ -86,15 +86,8 @@ get_fzf_find_binding() {
 
 FIND_BIND=$(get_fzf_find_binding)
 
-get_fzf_border_label() {
-	local fzf_border_label
-	local fzf_border_label_default=' t - smart tmux session manager '
-	if [ "$TMUX_RUNNING" -eq 0 ]; then
-		fzf_border_label="$(tmux show -gqv '@t-fzf-border-label')"
-	fi
-	[ -n "$fzf_border_label" ] && echo "$fzf_border_label" || echo "$fzf_border_label_default"
-}
-BORDER_LABEL=$(get_fzf_border_label)
+fzf_border_label_default=' t - smart tmux session manager '
+BORDER_LABEL=${T_FZF_BORDER_LABEL:-$fzf_border_label_default}
 
 HEADER=" ^s sessions ^x zoxide ^f find"
 SESSION_BIND="ctrl-s:change-prompt(sessions> )+reload(tmux list-sessions -F '#S')"
@@ -147,6 +140,7 @@ else # argument not provided
 				--bind "$SESSION_BIND" \
 				--bind "$TAB_BIND" \
 				--bind "$ZOXIDE_BIND" \
+				--border \
 				--border-label "$BORDER_LABEL" \
 				--header "$HEADER" \
 				--no-sort \
@@ -159,6 +153,7 @@ else # argument not provided
 				--bind "$FIND_BIND" \
 				--bind "$TAB_BIND" \
 				--bind "$ZOXIDE_BIND" \
+				--border \
 				--border-label "$BORDER_LABEL" \
 				--header " ^x zoxide ^f find" \
 				--no-sort \


### PR DESCRIPTION
- also fix: default fzf options is without --border, that caused the border label will not displayed in initial `t` call (serverless/detach)